### PR TITLE
docs: link production video services

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@
 
 </div>
 
+## Need a Production Video Workflow?
+
+VideoGo remains free and open source. If you need batch processing, transcription, subtitle translation, AI dubbing, multi-episode automation, or a team-local deployment, see [VideoHub](https://github.com/cacity/VideoHub) and its [fixed-scope services](https://github.com/cacity/VideoHub/blob/main/SERVICES.md).
+
+- Async environment diagnosis: **USD 149**
+- QuickStart setup: **USD 299**
+- Creator workflow: **USD 999**
+- Team local deployment: **USD 2,999**
+
+Contact: **stark fng** — [gf7823332@gmail.com](mailto:gf7823332@gmail.com). Please do not send passwords, tokens, cookies, or private media in the first message.
+
 ---
 
 ## ✨ 功能特性


### PR DESCRIPTION
﻿# What changed

- Add a concise VideoHub service link for users who need production-scale video workflows.
- Keep VideoGo free and open source.
- Publish fixed prices and a secret-safe first-contact rule.

# Why

DouyinGo has relevant public traffic and overlaps directly with VideoHub download, transcription, subtitle, dubbing, batch, and local-deployment workflows.

# Validation

- README-only change: 11 added lines.
- `git diff --check` passes.
- No application code, website, or GitHub issues changed.
