### PR TITLE
docs: route service requests to public GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ VideoGo remains free and open source. If you need batch processing, transcriptio
 - Creator workflow: **USD 999**
 - Team local deployment: **USD 2,999**
 
-Contact: **stark fng** — [gf7823332@gmail.com](mailto:gf7823332@gmail.com). Please do not send passwords, tokens, cookies, or private media in the first message.
+Contact: **stark fng** — open a [public VideoHub paid-support request](https://github.com/cacity/VideoHub/issues/new?template=paid-support.yml). Requests and follow-ups are not handled by email. Never post passwords, tokens, cookies, private media, customer data, or personal data in a public Issue.
 
 ---
 


### PR DESCRIPTION
## What changed

Replaces the obsolete email CTA with VideoHub's public paid-support Issue form.

## Why

Current commercial intake and follow-up are handled on public GitHub without outbound email. The new copy also warns against posting credentials, private media, customer data, or personal data.

## Boundaries

- no pricing or service-scope changes
- no website changes
- no existing Issue changes
- no email is sent

## Validation

- one-file diff
- no mailto or consultation email remains in README
- git diff --check passes