### PR TITLE
Route paid support from the issue chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Paid implementation support / 付费实施支持
+    url: https://github.com/cacity/VideoHub/issues/new?template=paid-support.yml
+    about: Fixed-scope diagnosis, setup, creator workflows, and team deployment from USD 149. Do not post secrets or private media.
+  - name: VideoHub service scope / VideoHub 服务范围
+    url: https://github.com/cacity/VideoHub/blob/main/SERVICES.md
+    about: Review prices, deliverables, acceptance checks, exclusions, and the public intake process before requesting support.


### PR DESCRIPTION
## Summary
- keep blank bug and feature Issues enabled
- add a paid implementation support contact link that routes to the existing VideoHub public form
- add a separate link to prices, deliverables, acceptance checks, and exclusions

## Boundaries
- no email or payment link
- no changes to existing Issues
- no website or ConvLSTM changes
- user's separate F:\\work\\DouyinGo staged deletion was not touched; this PR was built in an isolated clone

## Verification
- YAML parsed successfully
- exact public form URL and USD 149 entry point verified
- git diff --check